### PR TITLE
Remove warning and merge dev

### DIFF
--- a/src/generator/main.py
+++ b/src/generator/main.py
@@ -66,6 +66,9 @@ if __name__ == "__main__":
     with open(os.path.join(args.output_dir, "inc", "__init__.py"), "w") as file:
         print(f"✅ Generated __init__.py")
         pass
+    with open(os.path.join(args.output_dir, "__init__.py"), "w") as file:
+        print(f"✅ Generated __init__.py")
+        pass
     with open(os.path.join(args.output_dir, "inc", "message_parser.py"), "w") as file:
         file.write(message_parser_py_template.render(topics=topics, roles=roles))
         print(f"✅ Generated message_parser.py")

--- a/src/templates/topics.cpp.j2
+++ b/src/templates/topics.cpp.j2
@@ -17,7 +17,7 @@ std::vector<TopicMessage> GetSubscribeTopics(Role role
         case Role::{{ utils.role_enum_name(role) }}:
         {% for topic in topics -%}
         {% if role in topic['subscribe_roles'] -%}
-        ret.emplace_back(std::move({{ utils.topic_get_name(topic.alias) }}({{ utils.topic_get_variables_values(topic) }})));
+        ret.emplace_back({{ utils.topic_get_name(topic.alias) }}({{ utils.topic_get_variables_values(topic) }}));
         {% endif -%}
         {% endfor -%}
         break;

--- a/src/templates/topics.cpp.j2
+++ b/src/templates/topics.cpp.j2
@@ -41,7 +41,7 @@ std::vector<TopicMessage> GetPublishTopics(Role role
         case Role::{{ utils.role_enum_name(role) }}:
         {% for topic in topics -%}
         {% if role in topic['publish_roles'] -%}
-        ret.emplace_back(std::move({{ utils.topic_get_name(topic.alias) }}({{ utils.topic_get_variables_values(topic) }})));
+        ret.emplace_back({{ utils.topic_get_name(topic.alias) }}({{ utils.topic_get_variables_values(topic) }}));
         {% endif -%}
         {% endfor -%}
         break;

--- a/src/templates/topics.cpp.j2
+++ b/src/templates/topics.cpp.j2
@@ -74,8 +74,8 @@ bool CanSubscribe(Role role, Topic topic) {
             case Topic::{{ utils.topic_enum_name(topic.alias) }}:
             {% endif -%}
             {% endfor -%}
-            {% if ns.check != 0 %}  return false;
-            {%- else %}
+            {% if ns.check != 0 %}default:
+              return false;
             {%- endif %}
         }
         {%- if not loop.last%}
@@ -107,7 +107,9 @@ bool CanPublish(Role role, Topic topic) {
             case Topic::{{ utils.topic_enum_name(topic.alias) }}:
             {% endif -%}
             {% endfor -%}
-            {% if ns.check != 0 %}  return false;
+            {% if ns.check != 0 %} 
+            default: 
+              return false;
             {%- endif %}
         }
         {%- if not loop.last%}

--- a/topics_tree.jsonc
+++ b/topics_tree.jsonc
@@ -693,7 +693,7 @@
                 "alias": "ActionSetLapCounterStatus",
                 "description": "<vehicleId>/<deviceId>/action/setLapcounterStatus",
                 "qos": 2,
-                "subscribe_roles": ["128", "129"],
+                "subscribe_roles": ["128", "129", "131"],
                 "publish_roles": ["0", "1", "2", "3", "4"]
               }
             }

--- a/topics_tree.jsonc
+++ b/topics_tree.jsonc
@@ -244,25 +244,25 @@
             }
           },
           "as": {
-            "alias": "AS",
+            "alias": "As",
             "description": "<vehicleId>/<deviceId>/as",
             "qos": 2,
             "retain": false,
             "sub_topics": {
               "commands": {
-                "alias": "ASCommands",
+                "alias": "AsCommands",
                 "description": "<vehicleId>/<deviceId>/as/commands",
                 "qos": 2,
                 "retain": false,
                 "sub_topics": {
                   "setValues": {
-                    "alias": "ASCommandsSetValues",
+                    "alias": "AsCommandsSetValues",
                     "description": "<vehicleId>/<deviceId>/as/commands/setValues",
                     "subscribe_roles": ["0", "1", "2", "3", "4", "128", "129"],
                     "publish_roles": ["0", "128", "130"]
                   },
                   "setStatus": {
-                    "alias": "ASCommandsSetStatus",
+                    "alias": "AsCommandsSetStatus",
                     "description": "<vehicleId>/<deviceId>/as/commands/setStatus",
                     "subscribe_roles": ["0", "1", "2", "3", "4", "128", "129"],
                     "publish_roles": ["0", "128", "130"]


### PR DESCRIPTION
# Purpose

Fixes issue #9 by eliminating warnings.

# Overview

* merge dev into main
* remove unnecessary std::move()

# Guidance

No specific order is required for reviewing this PR.